### PR TITLE
Extend max query string length for PKCE

### DIFF
--- a/src/IdentityServer4Demo/foo.config
+++ b/src/IdentityServer4Demo/foo.config
@@ -4,7 +4,7 @@
     <system.webServer>
       <security>
         <requestFiltering>
-          <requestLimits maxQueryString="8192" />
+          <requestLimits maxQueryString="32768" />
         </requestFiltering>
       </security>
 


### PR DESCRIPTION
When using code authorisation, you might get 404 exception which is caused by too long query string.